### PR TITLE
Add HasProcess/HasRawPid Type Classes

### DIFF
--- a/src/Erl/Process.purs
+++ b/src/Erl/Process.purs
@@ -8,6 +8,8 @@ module Erl.Process
   , receiveWithTimeout
   , spawn
   , spawnLink
+  , class HasProcess
+  , getProcess
   ) where
 
 import Prelude
@@ -56,3 +58,12 @@ spawn (ProcessM e) = Process <$> Raw.spawn e
 
 spawnLink :: forall a. ProcessM a Unit -> Effect (Process a)
 spawnLink (ProcessM e) = Process <$> Raw.spawnLink e
+
+class HasProcess b a where
+  getProcess :: a -> Process b
+
+instance processHasProcess :: HasProcess b (Process b) where
+  getProcess = identity
+
+instance processHasRawPid :: Raw.HasRawPid (Process b) where
+  getRawPid (Process pid) = pid

--- a/src/Erl/Process/Raw.purs
+++ b/src/Erl/Process/Raw.purs
@@ -1,4 +1,14 @@
-module Erl.Process.Raw (Pid, spawn, spawnLink, send, receive, receiveWithTimeout, self) where
+module Erl.Process.Raw
+  ( Pid
+  , spawn
+  , spawnLink
+  , send
+  , receive
+  , receiveWithTimeout
+  , self
+  , class HasRawPid
+  , getRawPid
+  ) where
 
 import Prelude
 
@@ -21,3 +31,9 @@ foreign import receive :: forall a. Effect a
 foreign import receiveWithTimeout :: forall a. Int -> a -> Effect a
 
 foreign import self :: Effect Pid
+
+class HasRawPid a where
+  getRawPid :: a -> Pid
+
+instance pidHasRawPid :: HasRawPid Pid where
+  getRawPid = identity


### PR DESCRIPTION
These make it easy for folks to newtype over pids and processes to
create their own strongly-typed versions, whilst still being able to
create functions that work over them as if they were just plain ol' pids
and processes (Pinto uses this for GenStatem and GenServer).